### PR TITLE
unset baseurl in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 timezone:    America/New_York
-baseurl:     /
+baseurl:
 exclude:
   - reveal.js/test
   - reveal.js/index.html


### PR DESCRIPTION
I don't think there is a reason to have this set to `/`. It actually breaks local builds entirely.